### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+                php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 doctrine-version: [ '^2.19', '^3' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the CI test matrix to ensure compatibility with the upcoming PHP version

## Test plan
- [ ] CI pipeline passes with PHP 8.5 builds