### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "shipmonk/composer-dependency-analyser": "^1.7",
         "shipmonk/name-collision-detector": "^2.1.1",
         "shipmonk/phpstan-rules": "^4.0",
-        "symfony/cache": "^6 || ^7"
+        "symfony/cache": "^6 || ^7 || ^8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Updates `symfony/cache` dependency to allow Symfony 8 (`^6 || ^7 || ^8`)

## Test plan
- CI tests should pass to verify compatibility with Symfony 8