### PR TITLE
PHPStan: infer targetEntity from property type for ManyToOne associations

### DIFF
--- a/src/PHPStan/EntityPreloaderCore.php
+++ b/src/PHPStan/EntityPreloaderCore.php
@@ -21,6 +21,7 @@ use PHPStan\Type\UnionType;
 use ReflectionNamedType;
 use ReflectionProperty;
 use function count;
+use function in_array;
 use function is_string;
 
 abstract class EntityPreloaderCore
@@ -214,14 +215,17 @@ abstract class EntityPreloaderCore
             ManyToMany::class,
         ];
 
+        $toOneAssociations = [OneToOne::class, ManyToOne::class];
+
         foreach ($associationAttributes as $attributeClass) {
             foreach ($propertyReflection->getAttributes($attributeClass) as $attributeReflection) {
                 $attribute = $attributeReflection->newInstance();
 
                 if ($attribute->targetEntity !== null) {
                     return new ObjectType($attribute->targetEntity);
+                }
 
-                } elseif ($attributeClass === OneToOne::class && $propertyReflection->getType() instanceof ReflectionNamedType) {
+                if (in_array($attributeClass, $toOneAssociations, true) && $propertyReflection->getType() instanceof ReflectionNamedType) {
                     return new ObjectType($propertyReflection->getType()->getName());
                 }
             }

--- a/tests/Fixtures/Issue37/Employee.php
+++ b/tests/Fixtures/Issue37/Employee.php
@@ -2,106 +2,49 @@
 
 namespace ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\ReadableCollection;
-use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
-use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Synthetic\TestEntityWithId;
 
 /**
- * Test entity replicating GitHub issue #37
- * Uses associations WITHOUT explicit targetEntity attribute
- *
  * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
  */
 #[Entity]
 class Employee extends TestEntityWithId
 {
 
-    #[Column]
-    private string $name;
-
     /**
-     * ManyToOne WITHOUT explicit targetEntity - relies on type inference
+     * ManyToOne WITHOUT explicit targetEntity
      */
-    #[ManyToOne(inversedBy: 'subordinates')]
-    #[JoinColumn(onDelete: 'SET NULL')]
+    #[ManyToOne]
     private ?Employee $supervisor;
 
     /**
-     * OneToMany inverse side
-     *
-     * @var Collection<int, Employee>
+     * OneToOne WITHOUT explicit targetEntity
      */
-    #[OneToMany(targetEntity: self::class, mappedBy: 'supervisor')]
-    private Collection $subordinates;
-
-    /**
-     * OneToOne WITHOUT explicit targetEntity - relies on type inference
-     */
-    #[OneToOne(inversedBy: 'employee')]
-    #[JoinColumn(onDelete: 'SET NULL')]
-    private ?EmployeeSettings $settings = null;
+    #[OneToOne]
+    private ?EmployeeSettings $settings;
 
     public function __construct(
         ?int $number,
-        string $name,
-        ?self $supervisor = null,
+        ?Employee $supervisor = null,
+        ?EmployeeSettings $settings = null,
     )
     {
         $this->number = $number;
-        $this->name = $name;
         $this->supervisor = $supervisor;
-        $this->subordinates = new ArrayCollection();
-
-        $supervisor?->addSubordinate($this);
+        $this->settings = $settings;
     }
 
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function getSupervisor(): ?self
+    public function getSupervisor(): ?Employee
     {
         return $this->supervisor;
-    }
-
-    /**
-     * @return ReadableCollection<int, Employee>
-     */
-    public function getSubordinates(): ReadableCollection
-    {
-        return $this->subordinates;
     }
 
     public function getSettings(): ?EmployeeSettings
     {
         return $this->settings;
-    }
-
-    public function setSettings(?EmployeeSettings $settings): void
-    {
-        $this->settings = $settings;
-
-        if ($settings !== null) {
-            $settings->setEmployee($this);
-        }
-    }
-
-    /**
-     * @internal
-     */
-    public function addSubordinate(self $employee): void
-    {
-        if (!$this->subordinates->contains($employee)) {
-            $this->subordinates->add($employee);
-        }
     }
 
 }

--- a/tests/Fixtures/Issue37/Employee.php
+++ b/tests/Fixtures/Issue37/Employee.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ReadableCollection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
+use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Synthetic\TestEntityWithId;
+
+/**
+ * Test entity replicating GitHub issue #37
+ * Uses associations WITHOUT explicit targetEntity attribute
+ *
+ * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
+ */
+#[Entity]
+class Employee extends TestEntityWithId
+{
+
+    #[Column]
+    private string $name;
+
+    /**
+     * ManyToOne WITHOUT explicit targetEntity - relies on type inference
+     */
+    #[ManyToOne(inversedBy: 'subordinates')]
+    #[JoinColumn(onDelete: 'SET NULL')]
+    private ?Employee $supervisor;
+
+    /**
+     * OneToMany inverse side
+     *
+     * @var Collection<int, Employee>
+     */
+    #[OneToMany(targetEntity: self::class, mappedBy: 'supervisor')]
+    private Collection $subordinates;
+
+    /**
+     * OneToOne WITHOUT explicit targetEntity - relies on type inference
+     */
+    #[OneToOne(inversedBy: 'employee')]
+    #[JoinColumn(onDelete: 'SET NULL')]
+    private ?EmployeeSettings $settings = null;
+
+    public function __construct(
+        ?int $number,
+        string $name,
+        ?self $supervisor = null,
+    )
+    {
+        $this->number = $number;
+        $this->name = $name;
+        $this->supervisor = $supervisor;
+        $this->subordinates = new ArrayCollection();
+
+        $supervisor?->addSubordinate($this);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSupervisor(): ?self
+    {
+        return $this->supervisor;
+    }
+
+    /**
+     * @return ReadableCollection<int, Employee>
+     */
+    public function getSubordinates(): ReadableCollection
+    {
+        return $this->subordinates;
+    }
+
+    public function getSettings(): ?EmployeeSettings
+    {
+        return $this->settings;
+    }
+
+    public function setSettings(?EmployeeSettings $settings): void
+    {
+        $this->settings = $settings;
+
+        if ($settings !== null) {
+            $settings->setEmployee($this);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function addSubordinate(self $employee): void
+    {
+        if (!$this->subordinates->contains($employee)) {
+            $this->subordinates->add($employee);
+        }
+    }
+
+}

--- a/tests/Fixtures/Issue37/EmployeeSettings.php
+++ b/tests/Fixtures/Issue37/EmployeeSettings.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\OneToOne;
+use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Synthetic\TestEntityWithId;
+
+/**
+ * Test entity replicating GitHub issue #37
+ * Uses associations WITHOUT explicit targetEntity attribute
+ *
+ * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
+ */
+#[Entity]
+class EmployeeSettings extends TestEntityWithId
+{
+
+    #[Column]
+    private string $theme;
+
+    #[Column]
+    private string $locale;
+
+    /**
+     * OneToOne inverse side WITHOUT explicit targetEntity - relies on type inference
+     */
+    #[OneToOne(mappedBy: 'settings')]
+    private ?Employee $employee = null;
+
+    public function __construct(
+        ?int $number,
+        string $theme = 'light',
+        string $locale = 'en',
+    )
+    {
+        $this->number = $number;
+        $this->theme = $theme;
+        $this->locale = $locale;
+    }
+
+    public function getTheme(): string
+    {
+        return $this->theme;
+    }
+
+    public function setTheme(string $theme): void
+    {
+        $this->theme = $theme;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale): void
+    {
+        $this->locale = $locale;
+    }
+
+    public function getEmployee(): ?Employee
+    {
+        return $this->employee;
+    }
+
+    /**
+     * @internal
+     */
+    public function setEmployee(?Employee $employee): void
+    {
+        $this->employee = $employee;
+    }
+
+}

--- a/tests/Fixtures/Issue37/EmployeeSettings.php
+++ b/tests/Fixtures/Issue37/EmployeeSettings.php
@@ -2,75 +2,19 @@
 
 namespace ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37;
 
-use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\OneToOne;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Synthetic\TestEntityWithId;
 
 /**
- * Test entity replicating GitHub issue #37
- * Uses associations WITHOUT explicit targetEntity attribute
- *
  * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
  */
 #[Entity]
 class EmployeeSettings extends TestEntityWithId
 {
 
-    #[Column]
-    private string $theme;
-
-    #[Column]
-    private string $locale;
-
-    /**
-     * OneToOne inverse side WITHOUT explicit targetEntity - relies on type inference
-     */
-    #[OneToOne(mappedBy: 'settings')]
-    private ?Employee $employee = null;
-
-    public function __construct(
-        ?int $number,
-        string $theme = 'light',
-        string $locale = 'en',
-    )
+    public function __construct(?int $number)
     {
         $this->number = $number;
-        $this->theme = $theme;
-        $this->locale = $locale;
-    }
-
-    public function getTheme(): string
-    {
-        return $this->theme;
-    }
-
-    public function setTheme(string $theme): void
-    {
-        $this->theme = $theme;
-    }
-
-    public function getLocale(): string
-    {
-        return $this->locale;
-    }
-
-    public function setLocale(string $locale): void
-    {
-        $this->locale = $locale;
-    }
-
-    public function getEmployee(): ?Employee
-    {
-        return $this->employee;
-    }
-
-    /**
-     * @internal
-     */
-    public function setEmployee(?Employee $employee): void
-    {
-        $this->employee = $employee;
     }
 
 }

--- a/tests/PHPStan/Data/EntityPreloaderRuleTestData.php
+++ b/tests/PHPStan/Data/EntityPreloaderRuleTestData.php
@@ -13,6 +13,8 @@ use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\Contributor;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\PasswordVerifier;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\Tag;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\User;
+use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee;
+use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings;
 use function PHPStan\Testing\assertType;
 
 final class EntityPreloaderRuleTestData
@@ -112,6 +114,34 @@ final class EntityPreloaderRuleTestData
     public function preloadWithObject(array $entities): void
     {
         assertType('list<object>', $this->entityPreloader->preload($entities, 'foo')); // error: Property 'object::$foo' not found.
+    }
+
+    /**
+     * GitHub issue #37: Test associations WITHOUT explicit targetEntity attribute
+     * These use type inference from the property type, which should work with phpstan-doctrine
+     *
+     * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
+     */
+    public function preloadWithoutExplicitTargetEntity(): void
+    {
+        $employees = $this->entityManager->getRepository(Employee::class)->findAll();
+
+        // ManyToOne self-referencing WITHOUT targetEntity attribute - should infer from property type
+        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employees, 'supervisor'));
+
+        // OneToOne WITHOUT targetEntity attribute - should infer from property type
+        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings>', $this->entityPreloader->preload($employees, 'settings'));
+
+        // Preload nested: first supervisor, then their settings
+        $supervisors = $this->entityPreloader->preload($employees, 'supervisor');
+        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings>', $this->entityPreloader->preload($supervisors, 'settings'));
+
+        // OneToMany (has targetEntity) - should still work
+        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employees, 'subordinates'));
+
+        // Inverse side of OneToOne WITHOUT targetEntity
+        $employeeSettings = $this->entityManager->getRepository(EmployeeSettings::class)->findAll();
+        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employeeSettings, 'employee'));
     }
 
 }

--- a/tests/PHPStan/Data/EntityPreloaderRuleTestData.php
+++ b/tests/PHPStan/Data/EntityPreloaderRuleTestData.php
@@ -14,7 +14,6 @@ use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\PasswordVerifier;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\Tag;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Blog\User;
 use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee;
-use ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings;
 use function PHPStan\Testing\assertType;
 
 final class EntityPreloaderRuleTestData
@@ -117,31 +116,17 @@ final class EntityPreloaderRuleTestData
     }
 
     /**
-     * GitHub issue #37: Test associations WITHOUT explicit targetEntity attribute
-     * These use type inference from the property type, which should work with phpstan-doctrine
-     *
      * @see https://github.com/shipmonk-rnd/doctrine-entity-preloader/issues/37
      */
     public function preloadWithoutExplicitTargetEntity(): void
     {
         $employees = $this->entityManager->getRepository(Employee::class)->findAll();
 
-        // ManyToOne self-referencing WITHOUT targetEntity attribute - should infer from property type
+        // ManyToOne WITHOUT targetEntity attribute
         assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employees, 'supervisor'));
 
-        // OneToOne WITHOUT targetEntity attribute - should infer from property type
+        // OneToOne WITHOUT targetEntity attribute
         assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings>', $this->entityPreloader->preload($employees, 'settings'));
-
-        // Preload nested: first supervisor, then their settings
-        $supervisors = $this->entityPreloader->preload($employees, 'supervisor');
-        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\EmployeeSettings>', $this->entityPreloader->preload($supervisors, 'settings'));
-
-        // OneToMany (has targetEntity) - should still work
-        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employees, 'subordinates'));
-
-        // Inverse side of OneToOne WITHOUT targetEntity
-        $employeeSettings = $this->entityManager->getRepository(EmployeeSettings::class)->findAll();
-        assertType('list<ShipMonkTests\DoctrineEntityPreloader\Fixtures\Issue37\Employee>', $this->entityPreloader->preload($employeeSettings, 'employee'));
     }
 
 }


### PR DESCRIPTION
## Summary

- Extends PHPStan type inference to work for `ManyToOne` associations without explicit `targetEntity` attribute
- Previously only `OneToOne` associations could infer target entity from property type
- Adds test entities and test cases to verify the fix (reproduces issue #37)

## Problem

When using associations without explicit `targetEntity` attribute:

```php
#[ManyToOne(inversedBy: 'subordinates')]
public ?Employee $supervisor = null;
```

PHPStan would incorrectly report: "Property 'Employee::$supervisor' is not a valid Doctrine association."

## Solution

Extended the `getAssociationTargetTypeFromPropertyReflection` method to also infer target entity from property type for `ManyToOne` associations, not just `OneToOne`.

## Test plan

- [x] Added `Employee` and `EmployeeSettings` test entities replicating issue #37
- [x] Added test cases for associations without explicit `targetEntity`
- [x] All PHPStan integration tests pass (both with and without phpstan-doctrine)
- [x] All unit tests pass
- [x] PHPStan analysis passes
- [x] Code style checks pass

Fixes #37