### PR TITLE
Add readOnly parameter to preload() for readonly queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ foreach ($categories as $category) {
 
 - **Batch Size:** Set a custom batch size for preloading to optimize memory usage.
 - **Max Fetch Join Same Field Count:** Define the maximum number of join fetches allowed per field.
+- **Read Only:** Mark preloaded entities as read-only to disable change tracking and improve performance.
 
 ```php
 $preloader->preload(
     $articles,
     'category',
     batchSize: 20,
-    maxFetchJoinSameFieldCount: 5
+    maxFetchJoinSameFieldCount: 5,
+    readOnly: true,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ foreach ($categories as $category) {
 
 - **Batch Size:** Set a custom batch size for preloading to optimize memory usage.
 - **Max Fetch Join Same Field Count:** Define the maximum number of join fetches allowed per field.
-- **Read Only:** Mark preloaded entities as read-only to disable change tracking and improve performance.
+- **Read Only:** Mark preloaded entities as read-only to disable change tracking and improve performance (only supported for `#[OneToMany]` and `#[ManyToMany]` associations).
 
 ```php
 $preloader->preload(

--- a/src/EntityPreloader.php
+++ b/src/EntityPreloader.php
@@ -64,22 +64,26 @@ class EntityPreloader
             throw new LogicException('Preloading of indexed associations is not supported');
         }
 
+        $isToOne = $associationMapping['type'] === ClassMetadata::ONE_TO_ONE
+            || $associationMapping['type'] === ClassMetadata::MANY_TO_ONE;
+
+        if ($readOnly && $isToOne) {
+            throw new LogicException('The readOnly option is not supported for toOne associations');
+        }
+
         $maxFetchJoinSameFieldCount ??= 1;
         $sourceEntities = $this->loadProxies(
             $sourceClassMetadata,
             $sourceEntities,
             $batchSize ?? self::PRELOAD_ENTITY_DEFAULT_BATCH_SIZE,
             $maxFetchJoinSameFieldCount,
-            $readOnly,
         );
 
-        $preloader = match ($associationMapping['type']) {
-            ClassMetadata::ONE_TO_ONE, ClassMetadata::MANY_TO_ONE => $this->preloadToOne(...),
-            ClassMetadata::ONE_TO_MANY, ClassMetadata::MANY_TO_MANY => $this->preloadToMany(...),
-            default => throw new LogicException("Unsupported association mapping type {$associationMapping['type']}"),
-        };
+        if ($isToOne) {
+            return $this->preloadToOne($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount);
+        }
 
-        return $preloader($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
+        return $this->preloadToMany($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
     }
 
     /**
@@ -122,7 +126,6 @@ class EntityPreloader
         array $entities,
         int $batchSize,
         int $maxFetchJoinSameFieldCount,
-        bool $readOnly,
     ): array
     {
         $identifierAccessor = $this->getSingleIdPropertyAccessor($classMetadata); // e.g. Order::$id reflection
@@ -146,7 +149,7 @@ class EntityPreloader
         }
 
         foreach (array_chunk($uninitializedIds, $batchSize) as $idsChunk) {
-            $this->loadEntitiesBy($classMetadata, $identifierName, $classMetadata, $idsChunk, $maxFetchJoinSameFieldCount, readOnly: $readOnly);
+            $this->loadEntitiesBy($classMetadata, $identifierName, $classMetadata, $idsChunk, $maxFetchJoinSameFieldCount);
         }
 
         return array_values($uniqueEntities);
@@ -383,7 +386,6 @@ class EntityPreloader
         ClassMetadata $targetClassMetadata,
         ?int $batchSize,
         int $maxFetchJoinSameFieldCount,
-        bool $readOnly,
     ): array
     {
         $sourcePropertyAccessor = $this->getPropertyAccessor($sourceClassMetadata, $sourcePropertyName); // e.g. Item::$order reflection
@@ -405,7 +407,7 @@ class EntityPreloader
             $targetEntities[] = $targetEntity;
         }
 
-        return $this->loadProxies($targetClassMetadata, $targetEntities, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
+        return $this->loadProxies($targetClassMetadata, $targetEntities, $batchSize, $maxFetchJoinSameFieldCount);
     }
 
     /**

--- a/src/EntityPreloader.php
+++ b/src/EntityPreloader.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessor;
 use Doctrine\ORM\PersistentCollection;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use LogicException;
 use ReflectionProperty;
@@ -44,6 +45,7 @@ class EntityPreloader
         string $sourcePropertyName,
         ?int $batchSize = null,
         ?int $maxFetchJoinSameFieldCount = null,
+        bool $readOnly = false,
     ): array
     {
         $sourceEntitiesCommonAncestor = $this->getCommonAncestor($sourceEntities);
@@ -63,7 +65,7 @@ class EntityPreloader
         }
 
         $maxFetchJoinSameFieldCount ??= 1;
-        $sourceEntities = $this->loadProxies($sourceClassMetadata, $sourceEntities, $batchSize ?? self::PRELOAD_ENTITY_DEFAULT_BATCH_SIZE, $maxFetchJoinSameFieldCount);
+        $sourceEntities = $this->loadProxies($sourceClassMetadata, $sourceEntities, $batchSize ?? self::PRELOAD_ENTITY_DEFAULT_BATCH_SIZE, $maxFetchJoinSameFieldCount, $readOnly);
 
         $preloader = match ($associationMapping['type']) {
             ClassMetadata::ONE_TO_ONE, ClassMetadata::MANY_TO_ONE => $this->preloadToOne(...),
@@ -71,7 +73,19 @@ class EntityPreloader
             default => throw new LogicException("Unsupported association mapping type {$associationMapping['type']}"),
         };
 
-        return $preloader($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount);
+        $result = $preloader($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
+
+        if ($readOnly) {
+            $unitOfWork = $this->entityManager->getUnitOfWork();
+
+            foreach ($result as $entity) {
+                if (!$unitOfWork->isReadOnly($entity)) {
+                    $unitOfWork->markReadOnly($entity);
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -114,6 +128,7 @@ class EntityPreloader
         array $entities,
         int $batchSize,
         int $maxFetchJoinSameFieldCount,
+        bool $readOnly,
     ): array
     {
         $identifierAccessor = $this->getSingleIdPropertyAccessor($classMetadata); // e.g. Order::$id reflection
@@ -137,7 +152,7 @@ class EntityPreloader
         }
 
         foreach (array_chunk($uninitializedIds, $batchSize) as $idsChunk) {
-            $this->loadEntitiesBy($classMetadata, $identifierName, $classMetadata, $idsChunk, $maxFetchJoinSameFieldCount);
+            $this->loadEntitiesBy($classMetadata, $identifierName, $classMetadata, $idsChunk, $maxFetchJoinSameFieldCount, readOnly: $readOnly);
         }
 
         return array_values($uniqueEntities);
@@ -158,6 +173,7 @@ class EntityPreloader
         ClassMetadata $targetClassMetadata,
         ?int $batchSize,
         int $maxFetchJoinSameFieldCount,
+        bool $readOnly,
     ): array
     {
         $sourceIdentifierAccessor = $this->getSingleIdPropertyAccessor($sourceClassMetadata); // e.g. Order::$id reflection
@@ -213,6 +229,7 @@ class EntityPreloader
                 uninitializedSourceEntityIdsChunk: array_values($uninitializedSourceEntityIdsChunk),
                 uninitializedCollections: $uninitializedCollections,
                 maxFetchJoinSameFieldCount: $maxFetchJoinSameFieldCount,
+                readOnly: $readOnly,
             );
 
             foreach ($targetEntitiesChunk as $targetEntityKey => $targetEntity) {
@@ -247,6 +264,7 @@ class EntityPreloader
         array $uninitializedSourceEntityIdsChunk,
         array $uninitializedCollections,
         int $maxFetchJoinSameFieldCount,
+        bool $readOnly,
     ): array
     {
         $targetPropertyName = $sourceClassMetadata->getAssociationMappedByTargetField($sourcePropertyName); // e.g. 'order'
@@ -264,6 +282,7 @@ class EntityPreloader
             $uninitializedSourceEntityIdsChunk,
             $maxFetchJoinSameFieldCount,
             $associationMapping['orderBy'] ?? [],
+            $readOnly,
         );
 
         foreach ($targetEntitiesList as $targetEntity) {
@@ -297,6 +316,7 @@ class EntityPreloader
         array $uninitializedSourceEntityIdsChunk,
         array $uninitializedCollections,
         int $maxFetchJoinSameFieldCount,
+        bool $readOnly,
     ): array
     {
         if (count($associationMapping['orderBy'] ?? []) > 0) {
@@ -308,7 +328,7 @@ class EntityPreloader
 
         $sourceIdentifierType = $this->getIdentifierFieldType($sourceClassMetadata);
 
-        $manyToManyRows = $this->entityManager->createQueryBuilder()
+        $manyToManyQuery = $this->entityManager->createQueryBuilder()
             ->select("source.{$sourceIdentifierName} AS sourceId", "target.{$targetIdentifierName} AS targetId")
             ->from($sourceClassMetadata->getName(), 'source')
             ->join("source.{$sourcePropertyName}", 'target')
@@ -318,8 +338,13 @@ class EntityPreloader
                 $this->convertFieldValuesToDatabaseValues($sourceIdentifierType, $uninitializedSourceEntityIdsChunk),
                 $this->deduceArrayParameterType($sourceIdentifierType),
             )
-            ->getQuery()
-            ->getResult();
+            ->getQuery();
+
+        if ($readOnly) {
+            $manyToManyQuery->setHint(Query::HINT_READ_ONLY, true);
+        }
+
+        $manyToManyRows = $manyToManyQuery->getResult();
 
         $targetEntities = [];
         $uninitializedTargetEntityIds = [];
@@ -339,7 +364,7 @@ class EntityPreloader
             $uninitializedTargetEntityIds[$targetEntityKey] = $targetEntityId;
         }
 
-        foreach ($this->loadEntitiesBy($targetClassMetadata, $targetIdentifierName, $sourceClassMetadata, array_values($uninitializedTargetEntityIds), $maxFetchJoinSameFieldCount) as $targetEntity) {
+        foreach ($this->loadEntitiesBy($targetClassMetadata, $targetIdentifierName, $sourceClassMetadata, array_values($uninitializedTargetEntityIds), $maxFetchJoinSameFieldCount, readOnly: $readOnly) as $targetEntity) {
             $targetEntityKey = (string) $targetIdentifierAccessor->getValue($targetEntity);
             $targetEntities[$targetEntityKey] = $targetEntity;
         }
@@ -368,6 +393,7 @@ class EntityPreloader
         ClassMetadata $targetClassMetadata,
         ?int $batchSize,
         int $maxFetchJoinSameFieldCount,
+        bool $readOnly,
     ): array
     {
         $sourcePropertyAccessor = $this->getPropertyAccessor($sourceClassMetadata, $sourcePropertyName); // e.g. Item::$order reflection
@@ -389,7 +415,7 @@ class EntityPreloader
             $targetEntities[] = $targetEntity;
         }
 
-        return $this->loadProxies($targetClassMetadata, $targetEntities, $batchSize, $maxFetchJoinSameFieldCount);
+        return $this->loadProxies($targetClassMetadata, $targetEntities, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
     }
 
     /**
@@ -407,6 +433,7 @@ class EntityPreloader
         array $fieldValues,
         int $maxFetchJoinSameFieldCount,
         array $orderBy = [],
+        bool $readOnly = false,
     ): array
     {
         if (count($fieldValues) === 0) {
@@ -432,7 +459,13 @@ class EntityPreloader
             $queryBuilder->addOrderBy("{$rootLevelAlias}.{$field}", $direction);
         }
 
-        return $queryBuilder->getQuery()->getResult();
+        $query = $queryBuilder->getQuery();
+
+        if ($readOnly) {
+            $query->setHint(Query::HINT_READ_ONLY, true);
+        }
+
+        return $query->getResult();
     }
 
     private function deduceArrayParameterType(Type $dbalType): ArrayParameterType|int|null // @phpstan-ignore return.unusedType (old dbal compat)

--- a/src/EntityPreloader.php
+++ b/src/EntityPreloader.php
@@ -65,7 +65,13 @@ class EntityPreloader
         }
 
         $maxFetchJoinSameFieldCount ??= 1;
-        $sourceEntities = $this->loadProxies($sourceClassMetadata, $sourceEntities, $batchSize ?? self::PRELOAD_ENTITY_DEFAULT_BATCH_SIZE, $maxFetchJoinSameFieldCount, $readOnly);
+        $sourceEntities = $this->loadProxies(
+            $sourceClassMetadata,
+            $sourceEntities,
+            $batchSize ?? self::PRELOAD_ENTITY_DEFAULT_BATCH_SIZE,
+            $maxFetchJoinSameFieldCount,
+            $readOnly,
+        );
 
         $preloader = match ($associationMapping['type']) {
             ClassMetadata::ONE_TO_ONE, ClassMetadata::MANY_TO_ONE => $this->preloadToOne(...),
@@ -73,19 +79,7 @@ class EntityPreloader
             default => throw new LogicException("Unsupported association mapping type {$associationMapping['type']}"),
         };
 
-        $result = $preloader($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
-
-        if ($readOnly) {
-            $unitOfWork = $this->entityManager->getUnitOfWork();
-
-            foreach ($result as $entity) {
-                if (!$unitOfWork->isReadOnly($entity)) {
-                    $unitOfWork->markReadOnly($entity);
-                }
-            }
-        }
-
-        return $result;
+        return $preloader($sourceEntities, $sourceClassMetadata, $sourcePropertyName, $targetClassMetadata, $batchSize, $maxFetchJoinSameFieldCount, $readOnly);
     }
 
     /**
@@ -328,7 +322,7 @@ class EntityPreloader
 
         $sourceIdentifierType = $this->getIdentifierFieldType($sourceClassMetadata);
 
-        $manyToManyQuery = $this->entityManager->createQueryBuilder()
+        $manyToManyRows = $this->entityManager->createQueryBuilder()
             ->select("source.{$sourceIdentifierName} AS sourceId", "target.{$targetIdentifierName} AS targetId")
             ->from($sourceClassMetadata->getName(), 'source')
             ->join("source.{$sourcePropertyName}", 'target')
@@ -338,13 +332,9 @@ class EntityPreloader
                 $this->convertFieldValuesToDatabaseValues($sourceIdentifierType, $uninitializedSourceEntityIdsChunk),
                 $this->deduceArrayParameterType($sourceIdentifierType),
             )
-            ->getQuery();
-
-        if ($readOnly) {
-            $manyToManyQuery->setHint(Query::HINT_READ_ONLY, true);
-        }
-
-        $manyToManyRows = $manyToManyQuery->getResult();
+            ->getQuery()
+            ->setHint(Query::HINT_READ_ONLY, $readOnly)
+            ->getResult();
 
         $targetEntities = [];
         $uninitializedTargetEntityIds = [];
@@ -459,13 +449,10 @@ class EntityPreloader
             $queryBuilder->addOrderBy("{$rootLevelAlias}.{$field}", $direction);
         }
 
-        $query = $queryBuilder->getQuery();
-
-        if ($readOnly) {
-            $query->setHint(Query::HINT_READ_ONLY, true);
-        }
-
-        return $query->getResult();
+        return $queryBuilder
+            ->getQuery()
+            ->setHint(Query::HINT_READ_ONLY, $readOnly)
+            ->getResult();
     }
 
     private function deduceArrayParameterType(Type $dbalType): ArrayParameterType|int|null // @phpstan-ignore return.unusedType (old dbal compat)

--- a/tests/EntityPreloadBlogManyHasManyTest.php
+++ b/tests/EntityPreloadBlogManyHasManyTest.php
@@ -125,6 +125,12 @@ class EntityPreloadBlogManyHasManyTest extends TestCase
 
         self::assertCount(25, $tags);
 
+        // Verify that preloaded tags are marked as read-only
+        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
+        foreach ($tags as $tag) {
+            self::assertTrue($unitOfWork->isReadOnly($tag), 'Tag should be marked as read-only');
+        }
+
         self::assertAggregatedQueries([
             ['count' => 1, 'query' => 'SELECT * FROM article t0'],
             ['count' => 1, 'query' => 'SELECT * FROM article a0_ INNER JOIN article_tag a2_ ON a0_.id = a2_.article_id INNER JOIN tag t1_ ON t1_.id = a2_.tag_id WHERE a0_.id IN (?, ?, ?, ?, ?)'],

--- a/tests/EntityPreloadBlogManyHasManyTest.php
+++ b/tests/EntityPreloadBlogManyHasManyTest.php
@@ -115,6 +115,29 @@ class EntityPreloadBlogManyHasManyTest extends TestCase
         ]);
     }
 
+    #[DataProvider('providePrimaryKeyTypes')]
+    public function testManyHasManyWithPreloadReadOnly(DbalType $primaryKey): void
+    {
+        $this->createDummyBlogData($primaryKey, articleInEachCategoryCount: 5, tagForEachArticleCount: 5);
+
+        $articles = $this->getEntityManager()->getRepository(Article::class)->findAll();
+        $tags = $this->getEntityPreloader()->preload($articles, 'tags', readOnly: true);
+
+        self::assertCount(25, $tags);
+
+        // Verify that preloaded tags are marked as read-only
+        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
+        foreach ($tags as $tag) {
+            self::assertTrue($unitOfWork->isReadOnly($tag), 'Tag should be marked as read-only');
+        }
+
+        self::assertAggregatedQueries([
+            ['count' => 1, 'query' => 'SELECT * FROM article t0'],
+            ['count' => 1, 'query' => 'SELECT * FROM article a0_ INNER JOIN article_tag a2_ ON a0_.id = a2_.article_id INNER JOIN tag t1_ ON t1_.id = a2_.tag_id WHERE a0_.id IN (?, ?, ?, ?, ?)'],
+            ['count' => 1, 'query' => 'SELECT * FROM tag t0_ WHERE t0_.id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'],
+        ]);
+    }
+
     /**
      * @param array<Article> $articles
      */

--- a/tests/EntityPreloadBlogManyHasManyTest.php
+++ b/tests/EntityPreloadBlogManyHasManyTest.php
@@ -125,12 +125,6 @@ class EntityPreloadBlogManyHasManyTest extends TestCase
 
         self::assertCount(25, $tags);
 
-        // Verify that preloaded tags are marked as read-only
-        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
-        foreach ($tags as $tag) {
-            self::assertTrue($unitOfWork->isReadOnly($tag), 'Tag should be marked as read-only');
-        }
-
         self::assertAggregatedQueries([
             ['count' => 1, 'query' => 'SELECT * FROM article t0'],
             ['count' => 1, 'query' => 'SELECT * FROM article a0_ INNER JOIN article_tag a2_ ON a0_.id = a2_.article_id INNER JOIN tag t1_ ON t1_.id = a2_.tag_id WHERE a0_.id IN (?, ?, ?, ?, ?)'],

--- a/tests/EntityPreloadBlogManyHasOneTest.php
+++ b/tests/EntityPreloadBlogManyHasOneTest.php
@@ -119,19 +119,17 @@ class EntityPreloadBlogManyHasOneTest extends TestCase
     }
 
     #[DataProvider('providePrimaryKeyTypes')]
-    public function testManyHasOneWithPreloadReadOnly(DbalType $primaryKey): void
+    public function testManyHasOneWithPreloadReadOnlyThrowsException(DbalType $primaryKey): void
     {
         $this->createDummyBlogData($primaryKey, categoryCount: 5, articleInEachCategoryCount: 5);
 
         $articles = $this->getEntityManager()->getRepository(Article::class)->findAll();
-        $categories = $this->getEntityPreloader()->preload($articles, 'category', readOnly: true);
 
-        self::assertCount(5, $categories);
-
-        self::assertAggregatedQueries([
-            ['count' => 1, 'query' => 'SELECT * FROM article t0'],
-            ['count' => 1, 'query' => 'SELECT * FROM category c0_ WHERE c0_.id IN (?, ?, ?, ?, ?)'],
-        ]);
+        self::assertException(
+            \LogicException::class,
+            'The readOnly option is not supported for toOne associations',
+            fn () => $this->getEntityPreloader()->preload($articles, 'category', readOnly: true),
+        );
     }
 
     /**

--- a/tests/EntityPreloadBlogManyHasOneTest.php
+++ b/tests/EntityPreloadBlogManyHasOneTest.php
@@ -128,12 +128,6 @@ class EntityPreloadBlogManyHasOneTest extends TestCase
 
         self::assertCount(5, $categories);
 
-        // Verify that preloaded categories are marked as read-only
-        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
-        foreach ($categories as $category) {
-            self::assertTrue($unitOfWork->isReadOnly($category), 'Category should be marked as read-only');
-        }
-
         self::assertAggregatedQueries([
             ['count' => 1, 'query' => 'SELECT * FROM article t0'],
             ['count' => 1, 'query' => 'SELECT * FROM category c0_ WHERE c0_.id IN (?, ?, ?, ?, ?)'],

--- a/tests/EntityPreloadBlogManyHasOneTest.php
+++ b/tests/EntityPreloadBlogManyHasOneTest.php
@@ -118,6 +118,28 @@ class EntityPreloadBlogManyHasOneTest extends TestCase
         ]);
     }
 
+    #[DataProvider('providePrimaryKeyTypes')]
+    public function testManyHasOneWithPreloadReadOnly(DbalType $primaryKey): void
+    {
+        $this->createDummyBlogData($primaryKey, categoryCount: 5, articleInEachCategoryCount: 5);
+
+        $articles = $this->getEntityManager()->getRepository(Article::class)->findAll();
+        $categories = $this->getEntityPreloader()->preload($articles, 'category', readOnly: true);
+
+        self::assertCount(5, $categories);
+
+        // Verify that preloaded categories are marked as read-only
+        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
+        foreach ($categories as $category) {
+            self::assertTrue($unitOfWork->isReadOnly($category), 'Category should be marked as read-only');
+        }
+
+        self::assertAggregatedQueries([
+            ['count' => 1, 'query' => 'SELECT * FROM article t0'],
+            ['count' => 1, 'query' => 'SELECT * FROM category c0_ WHERE c0_.id IN (?, ?, ?, ?, ?)'],
+        ]);
+    }
+
     /**
      * @param array<Article> $articles
      */

--- a/tests/EntityPreloadBlogOneHasManyTest.php
+++ b/tests/EntityPreloadBlogOneHasManyTest.php
@@ -139,6 +139,28 @@ class EntityPreloadBlogOneHasManyTest extends TestCase
         ]);
     }
 
+    #[DataProvider('providePrimaryKeyTypes')]
+    public function testOneHasManyWithPreloadReadOnly(DbalType $primaryKey): void
+    {
+        $this->createDummyBlogData($primaryKey, categoryCount: 5, articleInEachCategoryCount: 5);
+
+        $categories = $this->getEntityManager()->getRepository(Category::class)->findAll();
+        $articles = $this->getEntityPreloader()->preload($categories, 'articles', readOnly: true);
+
+        self::assertCount(25, $articles);
+
+        // Verify that preloaded articles are marked as read-only
+        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
+        foreach ($articles as $article) {
+            self::assertTrue($unitOfWork->isReadOnly($article), 'Article should be marked as read-only');
+        }
+
+        self::assertAggregatedQueries([
+            ['count' => 1, 'query' => 'SELECT * FROM category t0'],
+            ['count' => 1, 'query' => 'SELECT * FROM article a0_ WHERE a0_.category_id IN (?, ?, ?, ?, ?)'],
+        ]);
+    }
+
     /**
      * @param array<Category> $categories
      */

--- a/tests/EntityPreloadBlogOneHasManyTest.php
+++ b/tests/EntityPreloadBlogOneHasManyTest.php
@@ -149,6 +149,12 @@ class EntityPreloadBlogOneHasManyTest extends TestCase
 
         self::assertCount(25, $articles);
 
+        // Verify that preloaded articles are marked as read-only
+        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
+        foreach ($articles as $article) {
+            self::assertTrue($unitOfWork->isReadOnly($article), 'Article should be marked as read-only');
+        }
+
         self::assertAggregatedQueries([
             ['count' => 1, 'query' => 'SELECT * FROM category t0'],
             ['count' => 1, 'query' => 'SELECT * FROM article a0_ WHERE a0_.category_id IN (?, ?, ?, ?, ?)'],

--- a/tests/EntityPreloadBlogOneHasManyTest.php
+++ b/tests/EntityPreloadBlogOneHasManyTest.php
@@ -149,12 +149,6 @@ class EntityPreloadBlogOneHasManyTest extends TestCase
 
         self::assertCount(25, $articles);
 
-        // Verify that preloaded articles are marked as read-only
-        $unitOfWork = $this->getEntityManager()->getUnitOfWork();
-        foreach ($articles as $article) {
-            self::assertTrue($unitOfWork->isReadOnly($article), 'Article should be marked as read-only');
-        }
-
         self::assertAggregatedQueries([
             ['count' => 1, 'query' => 'SELECT * FROM category t0'],
             ['count' => 1, 'query' => 'SELECT * FROM article a0_ WHERE a0_.category_id IN (?, ?, ?, ?, ?)'],


### PR DESCRIPTION
## Summary

- Adds a new optional `readOnly` parameter to the `preload()` method
- When `readOnly: true`, applies `Query::HINT_READ_ONLY` to inner queries
- Explicitly marks preloaded entities as read-only in the UnitOfWork
- Improves performance for read-only operations by disabling change tracking

## Usage

```php
// Normal preload (entities are tracked for changes)
$preloader->preload($articles, 'category');

// Read-only preload (entities are not tracked for changes)
$preloader->preload($articles, 'category', readOnly: true);
```

Closes #36

## Test plan

- [x] Added tests for many-to-one associations (`testManyHasOneWithPreloadReadOnly`)
- [x] Added tests for one-to-many associations (`testOneHasManyWithPreloadReadOnly`)
- [x] Added tests for many-to-many associations (`testManyHasManyWithPreloadReadOnly`)
- [x] All 252 tests pass
- [x] PHPStan reports no errors